### PR TITLE
Create a list of follow up messages

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -1,0 +1,15 @@
+["Bonjour ! I enjoyed your profile and think we might get along. Want to meet over coffee some time next week?",
+
+"If you like pastries, I know a good place downtown that has lemon puffs, chocolate pies, fruit tarts, and macaroons!",
+
+"Fine, if you don't like coffee nor pastries, we can do tea. How does tea sound?",
+
+"Yeah, you are right. Tea is a little boring. We should get ice cream! How about the Bi-Rite Creamery?",
+
+"I agree, ice cream is too cliché. We should do something no one else does on a first date, like meet at a gas station and get beef jerky! Think of the stories we could tell our grandkids!",
+
+"Alright, I'll admit that meeting at a gas station isn't the most romantic. And let's be honest: American food portions are so large we don't need more calories. How about a boat ride on Stow Lake? We can get a nice pedal boat and get fresh air and plenty of exercise. How about that?",
+
+"I see you don't want to cultivate the body; how about we cultivate the mind instead? There's a Long Now foundation talk coming up, and the Castro Theatre regularly has intellectual cinema classics. How about going to one of those?",
+
+"If San Francisco didn't have so much to offer, I'd be running out of ideas by now! Fortunately it is not so. Have you ever been to the opera? If not, you should! And I'll take you there!"]


### PR DESCRIPTION
Since not everyone responds immediately, for lack of time or because of an interrupt, it is sometimes necessary to send reminders to bump ourselves back to the top of the message queue. This is tricky, because a real person is supposed to be sending the messages, and repeating the same one will be seen as the act of a bot. If we don't do this, we'll be forgotten and never in contact.

I suggesting we use this series of messages that build upon the previous with the assumption that the previous one was read but not answered. 

We'll want to add some abstraction so the messages can be used outside of San Francisco.
